### PR TITLE
Make M face-centered

### DIFF
--- a/Exec/inputs_exchange
+++ b/Exec/inputs_exchange
@@ -1,0 +1,31 @@
+n_cell = 64 64 64
+max_grid_size = 32
+dt = 1.0e-15
+nsteps = 100
+plot_int = 10
+
+Phi_Bc_hi = 0.0
+Phi_Bc_lo = 0.0
+
+TimeIntegratorOrder = 1
+
+prob_lo = -16.e-9 -16.e-9 -16.e-9
+prob_hi =  16.e-9  16.e-9  16.e-9
+
+mag_lo = -8.e-9 -8.e-9 -8.e-9
+mag_hi =  8.e-9  8.e-9  8.e-9
+
+mu0 = 1.25663706212e-6 
+alpha_val = 0.058
+Ms_val = 1.4e5
+gamma_val = -1.759e11
+exchange_val = 3.76e-12
+anisotropy_val = -139.26
+anisotropy_axis = 0.0 1.0 0.0
+
+demag_coupling = 0
+M_normalization = 1
+exchange_coupling = 1
+anisotropy_coupling = 0
+
+

--- a/Source/MagLaplacian.H
+++ b/Source/MagLaplacian.H
@@ -5,10 +5,10 @@
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real UpwardDx (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dx = 1./dx[0];
-    return inv_dx*( F(i+1,j,k) - F(i,j,k) );
+    return inv_dx*( F(i+1,j,k,ncomp) - F(i,j,k,ncomp) );
 }
 
 
@@ -17,10 +17,10 @@ static amrex::Real UpwardDx (
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real DownwardDx (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dx = 1./dx[0];
-    return inv_dx*( F(i,j,k) - F(i-1,j,k) );
+    return inv_dx*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
 }
 
 
@@ -29,10 +29,10 @@ static amrex::Real DownwardDx (
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real UpwardDy (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dy = 1./dx[1];
-    return inv_dy*( F(i,j+1,k) - F(i,j,k) );
+    return inv_dy*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
 }
 
 
@@ -41,10 +41,10 @@ static amrex::Real UpwardDy (
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real DownwardDy (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dy = 1./dx[1];
-    return inv_dy*( F(i,j,k) - F(i,j-1,k) );
+    return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
 }
 
 
@@ -54,10 +54,10 @@ static amrex::Real DownwardDy (
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real UpwardDz (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dz = 1./dx[2];
-    return inv_dz*( F(i,j,k+1) - F(i,j,k) );
+    return inv_dz*( F(i,j,k+1,ncomp) - F(i,j,k,ncomp) );
 }
 
 
@@ -66,10 +66,10 @@ static amrex::Real UpwardDz (
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 static amrex::Real DownwardDz (
     amrex::Array4<amrex::Real> const& F,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp) {
 
     amrex::Real const inv_dz = 1./dx[2];
-    return inv_dz*( F(i,j,k) - F(i,j,k-1) );
+    return inv_dz*( F(i,j,k,ncomp) - F(i,j,k-1,ncomp) );
 }
 
 /**
@@ -78,16 +78,28 @@ static amrex::Real DownwardDz (
  static amrex::Real LaplacianDx_Mag (
     amrex::Array4<amrex::Real> const& F,
     amrex::Real const Ms_lo_x, amrex::Real const Ms_hi_x,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp, int const nodality) {
 
     amrex::Real const inv_dx = 1./dx[0];
-    if (Ms_hi_x == 0.){
-        return inv_dx*(0. - DownwardDx(F, i, j, k, dx));
-    } else if (Ms_lo_x == 0.){
-        return inv_dx*(UpwardDx(F, i, j, k, dx) - 0.);
-    } else {
-        return inv_dx*(UpwardDx(F, i, j, k, dx) - DownwardDx(F, i, j, k, dx));
+    if (nodality == 0){ // x face (normal face) dM/dx = 0
+       if ( Ms_hi_x == 0.) {
+           return 0.5 * inv_dx * inv_dx * (8. * F(i-1, j, k, ncomp) - F(i-2, j, k, ncomp) - 7. * F(i, j, k, ncomp));
+       } else if ( Ms_lo_x == 0.){
+           return 0.5 * inv_dx * inv_dx * (8. * F(i+1, j, k, ncomp) - F(i+2, j, k, ncomp) - 7. * F(i, j, k, ncomp));
+       } else {
+           return inv_dx*(UpwardDx(F, i, j, k, dx, ncomp) - DownwardDx(F, i, j, k, dx, ncomp));
+       }
+
+    } else { //y or z face
+       if ( Ms_hi_x == 0.) {
+           return inv_dx*(0. - DownwardDx(F, i, j, k, dx, ncomp));
+       } else if ( Ms_lo_x == 0.){
+           return inv_dx*(UpwardDx(F, i, j, k, dx, ncomp) - 0.);
+       } else {
+           return inv_dx*(UpwardDx(F, i, j, k, dx, ncomp) - DownwardDx(F, i, j, k, dx, ncomp));
+       }
     }
+
  }
 
 
@@ -97,16 +109,28 @@ static amrex::Real DownwardDz (
  static amrex::Real LaplacianDy_Mag (
     amrex::Array4<amrex::Real> const& F,
     amrex::Real const Ms_lo_y, amrex::Real const Ms_hi_y,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp, int const nodality) {
 
     amrex::Real const inv_dy = 1./dx[1];
-    if (Ms_hi_y == 0.){
-        return inv_dy*(0. - DownwardDy(F, i, j, k, dx));
-    } else if (Ms_lo_y == 0.){
-        return inv_dy*(UpwardDy(F, i, j, k, dx) - 0.);
-    } else {
-        return inv_dy*(UpwardDy(F, i, j, k, dx) - DownwardDy(F, i, j, k, dx));
+    if (nodality == 1){ // y face (normal face) dM/dy = 0
+       if ( Ms_hi_y == 0.) {
+           return 0.5 * inv_dy * inv_dy * (8. * F(i, j-1, k, ncomp) - F(i, j-2, k, ncomp) - 7. * F(i, j, k, ncomp));
+       } else if ( Ms_lo_y == 0.){
+           return 0.5 * inv_dy * inv_dy * (8. * F(i, j+1, k, ncomp) - F(i, j+2, k, ncomp) - 7. * F(i, j, k, ncomp));
+       } else {
+           return inv_dy*(UpwardDy(F, i, j, k, dx, ncomp) - DownwardDy(F, i, j, k, dx, ncomp));
+       }
+
+    } else { // x or z face
+       if ( Ms_hi_y == 0.) {
+           return inv_dy*(0. - DownwardDy(F, i, j, k, dx, ncomp));
+       } else if ( Ms_lo_y == 0.){
+           return inv_dy*(UpwardDy(F, i, j, k, dx, ncomp) - 0.);
+       } else {
+           return inv_dy*(UpwardDy(F, i, j, k, dx, ncomp) - DownwardDy(F, i, j, k, dx, ncomp));
+       }
     }
+
  }
 
 
@@ -116,16 +140,28 @@ static amrex::Real DownwardDz (
  static amrex::Real LaplacianDz_Mag (
     amrex::Array4<amrex::Real> const& F,
     amrex::Real const Ms_lo_z, amrex::Real const Ms_hi_z,
-    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+    int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp, int const nodality) {
 
     amrex::Real const inv_dz = 1./dx[2];
-    if (Ms_hi_z == 0.){
-        return inv_dz*(0. - DownwardDz(F, i, j, k, dx));
-    } else if (Ms_lo_z == 0.){
-        return inv_dz*(UpwardDz(F, i, j, k, dx) - 0.);
-    } else {
-        return inv_dz*(UpwardDz(F, i, j, k, dx) - DownwardDz(F, i, j, k, dx));
+    if (nodality == 2){ // z face (normal face) dM/dz = 0
+       if ( Ms_hi_z == 0.) {
+           return 0.5 * inv_dz * inv_dz * (8. * F(i, j, k-1, ncomp) - F(i, j, k-2, ncomp) - 7. * F(i, j, k, ncomp));
+       } else if ( Ms_lo_z == 0.){
+           return 0.5 * inv_dz * inv_dz * (8. * F(i, j, k+1, ncomp) - F(i, j, k+2, ncomp) - 7. * F(i, j, k, ncomp));
+       } else {
+           return inv_dz*(UpwardDz(F, i, j, k, dx, ncomp) - DownwardDz(F, i, j, k, dx, ncomp));
+       }
+
+    } else { // x or y face
+       if ( Ms_hi_z == 0.) {
+           return inv_dz*(0. - DownwardDz(F, i, j, k, dx, ncomp));
+       } else if ( Ms_lo_z == 0.){
+           return inv_dz*(UpwardDz(F, i, j, k, dx, ncomp) - 0.);
+       } else {
+           return inv_dz*(UpwardDz(F, i, j, k, dx, ncomp) - DownwardDz(F, i, j, k, dx, ncomp));
+       }
     }
+
  }
 
 /**
@@ -134,9 +170,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  static amrex::Real Laplacian_Mag (
      amrex::Array4<amrex::Real> const& F,
      amrex::Real const Ms_lo_x, amrex::Real const Ms_hi_x, amrex::Real const Ms_lo_y, amrex::Real const Ms_hi_y, amrex::Real const Ms_lo_z, amrex::Real const Ms_hi_z,
-     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx) {
+     int const i, int const j, int const k, amrex::GpuArray<amrex::Real, 3> dx, int const ncomp, int const nodality) {
 
      //amrex::Print() << "This is called " << Ms_lo_x << "\n";
-     return LaplacianDx_Mag(F, Ms_lo_x, Ms_hi_x, i, j, k, dx) + LaplacianDy_Mag(F, Ms_lo_y, Ms_hi_y, i, j, k, dx) + LaplacianDz_Mag(F, Ms_lo_z, Ms_hi_z, i, j, k, dx);
+     return LaplacianDx_Mag(F, Ms_lo_x, Ms_hi_x, i, j, k, dx, ncomp, nodality) + LaplacianDy_Mag(F, Ms_lo_y, Ms_hi_y, i, j, k, dx, ncomp, nodality) + LaplacianDz_Mag(F, Ms_lo_z, Ms_hi_z, i, j, k, dx, ncomp, nodality);
  }
 

--- a/Source/MicroMag.H
+++ b/Source/MicroMag.H
@@ -4,11 +4,11 @@
 
 using namespace amrex;
 
-void InitializeMagneticProperties(MultiFab&  alpha,
-                   MultiFab&   Ms, 
-                   MultiFab&   gamma,
-                   MultiFab&   exchange,
-                   MultiFab&   anisotropy,
+void InitializeMagneticProperties(std::array< MultiFab, AMREX_SPACEDIM >&  alpha,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   Ms, 
+                   std::array< MultiFab, AMREX_SPACEDIM >&   gamma,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   exchange,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   anisotropy,
                    Real        alpha_val,
                    Real        Ms_val,
                    Real        gamma_val,

--- a/Source/MicroMag.cpp
+++ b/Source/MicroMag.cpp
@@ -1,11 +1,11 @@
 #include "MicroMag.H"
 
 
-void InitializeMagneticProperties(MultiFab&  alpha,
-                   MultiFab&   Ms,
-                   MultiFab&   gamma,
-                   MultiFab&   exchange,
-                   MultiFab&   anisotropy,
+void InitializeMagneticProperties(std::array< MultiFab, AMREX_SPACEDIM >&  alpha,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   Ms,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   gamma,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   exchange,
+                   std::array< MultiFab, AMREX_SPACEDIM >&   anisotropy,
                    Real        alpha_val,
                    Real        Ms_val,
                    Real        gamma_val,
@@ -18,52 +18,115 @@ void InitializeMagneticProperties(MultiFab&  alpha,
                    const       Geometry& geom)
 {
 
-    alpha.setVal(0.);
-    Ms.setVal(0.);
-    gamma.setVal(0.);
-    exchange.setVal(0.);
-    anisotropy.setVal(0.);
+    for(int i = 0; i < 3; i++){
+       alpha[i].setVal(0.);
+       Ms[i].setVal(0.);
+       gamma[i].setVal(0.);
+       exchange[i].setVal(0.);
+       anisotropy[i].setVal(0.);
+    }
 
     // loop over boxes
-    for (MFIter mfi(alpha); mfi.isValid(); ++mfi)
+    for (MFIter mfi(alpha[0]); mfi.isValid(); ++mfi)
     {
         const Box& bx = mfi.validbox();
+
+        Box const &tbx = mfi.tilebox(alpha[0].ixType().toIntVect());
+        Box const &tby = mfi.tilebox(alpha[1].ixType().toIntVect());
+        Box const &tbz = mfi.tilebox(alpha[2].ixType().toIntVect());
 
         // extract dx from the geometry object
         GpuArray<Real,AMREX_SPACEDIM> dx = geom.CellSizeArray();
         
-        const Array4<Real>& alpha_arr = alpha.array(mfi);
-        const Array4<Real>& gamma_arr = gamma.array(mfi);
-        const Array4<Real>& Ms_arr = Ms.array(mfi);
-        const Array4<Real>& exchange_arr = exchange.array(mfi);
-        const Array4<Real>& anisotropy_arr = anisotropy.array(mfi);
+        const Array4<Real>& alpha_xface_arr = alpha[0].array(mfi);
+        const Array4<Real>& alpha_yface_arr = alpha[1].array(mfi);
+        const Array4<Real>& alpha_zface_arr = alpha[2].array(mfi);
 
-        amrex::ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        const Array4<Real>& gamma_xface_arr = gamma[0].array(mfi);
+        const Array4<Real>& gamma_yface_arr = gamma[1].array(mfi);
+        const Array4<Real>& gamma_zface_arr = gamma[2].array(mfi);
+
+        const Array4<Real>& Ms_xface_arr = Ms[0].array(mfi);
+        const Array4<Real>& Ms_yface_arr = Ms[1].array(mfi);
+        const Array4<Real>& Ms_zface_arr = Ms[2].array(mfi);
+
+        const Array4<Real>& exchange_xface_arr = exchange[0].array(mfi);
+        const Array4<Real>& exchange_yface_arr = exchange[1].array(mfi);
+        const Array4<Real>& exchange_zface_arr = exchange[2].array(mfi);
+
+        const Array4<Real>& anisotropy_xface_arr = anisotropy[0].array(mfi);
+        const Array4<Real>& anisotropy_yface_arr = anisotropy[1].array(mfi);
+        const Array4<Real>& anisotropy_zface_arr = anisotropy[2].array(mfi);
+
+        //xface
+        amrex::ParallelFor( tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real x = prob_lo[0] + (i+0.5) * dx[0];
+            Real x = prob_lo[0] + i * dx[0];
             Real y = prob_lo[1] + (j+0.5) * dx[1];
             Real z = prob_lo[2] + (k+0.5) * dx[2];
              
             if (x > mag_lo[0] && x < mag_hi[0]){
                if (y > mag_lo[1] && y < mag_hi[1]){
                   if (z > mag_lo[2] && z < mag_hi[2]){
-                     alpha_arr(i,j,k) = alpha_val;
-                     gamma_arr(i,j,k) = gamma_val;
-                     Ms_arr(i,j,k) = Ms_val;
-                     exchange_arr(i,j,k) = exchange_val;
-                     anisotropy_arr(i,j,k) = anisotropy_val;
+                     alpha_xface_arr(i,j,k) = alpha_val;
+                     gamma_xface_arr(i,j,k) = gamma_val;
+                     Ms_xface_arr(i,j,k) = Ms_val;
+                     exchange_xface_arr(i,j,k) = exchange_val;
+                     anisotropy_xface_arr(i,j,k) = anisotropy_val;
+                  }
+               }
+            }
+        }); 
+
+        //yface
+        amrex::ParallelFor( tby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            Real x = prob_lo[0] + (i+0.5) * dx[0];
+            Real y = prob_lo[1] + j * dx[1];
+            Real z = prob_lo[2] + (k+0.5) * dx[2];
+             
+            if (x > mag_lo[0] && x < mag_hi[0]){
+               if (y > mag_lo[1] && y < mag_hi[1]){
+                  if (z > mag_lo[2] && z < mag_hi[2]){
+                     alpha_yface_arr(i,j,k) = alpha_val;
+                     gamma_yface_arr(i,j,k) = gamma_val;
+                     Ms_yface_arr(i,j,k) = Ms_val;
+                     exchange_yface_arr(i,j,k) = exchange_val;
+                     anisotropy_yface_arr(i,j,k) = anisotropy_val;
+                  }
+               }
+            }
+        }); 
+
+        //zface
+        amrex::ParallelFor( tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            Real x = prob_lo[0] + (i+0.5) * dx[0];
+            Real y = prob_lo[1] + (j+0.5) * dx[1];
+            Real z = prob_lo[2] + k * dx[2];
+             
+            if (x > mag_lo[0] && x < mag_hi[0]){
+               if (y > mag_lo[1] && y < mag_hi[1]){
+                  if (z > mag_lo[2] && z < mag_hi[2]){
+                     alpha_zface_arr(i,j,k) = alpha_val;
+                     gamma_zface_arr(i,j,k) = gamma_val;
+                     Ms_zface_arr(i,j,k) = Ms_val;
+                     exchange_zface_arr(i,j,k) = exchange_val;
+                     anisotropy_zface_arr(i,j,k) = anisotropy_val;
                   }
                }
             }
         }); 
      }
-     // fill periodic ghost cells
-     alpha.FillBoundary(geom.periodicity());
-     Ms.FillBoundary(geom.periodicity());
-     gamma.FillBoundary(geom.periodicity());
-     exchange.FillBoundary(geom.periodicity());
-     anisotropy.FillBoundary(geom.periodicity());
-
+//     // fill periodic ghost cells
+//    for(int i = 0; i < 3; i++){
+//       alpha[i].FillBoundary(geom.periodicity());
+//       Ms[i].FillBoundary(geom.periodicity());
+//       gamma[i].FillBoundary(geom.periodicity());
+//       exchange[i].FillBoundary(geom.periodicity());
+//       anisotropy[i].FillBoundary(geom.periodicity());
+//    }
+//
 } 
 
 /*

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -219,9 +219,9 @@ void main_main ()
 
     Array<MultiFab, AMREX_SPACEDIM> H_biasfield;
     // face-centered H_biasfield
-    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
-                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
-                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
+    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
+                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
+                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
 
     //Face-centered magnetic properties
     std::array< MultiFab, AMREX_SPACEDIM > alpha;
@@ -235,9 +235,9 @@ void main_main ()
                  gamma[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
 
     std::array< MultiFab, AMREX_SPACEDIM > Ms;
-    AMREX_D_TERM(Ms[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
-                 Ms[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
-                 Ms[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
+    AMREX_D_TERM(Ms[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, Nghost);,
+                 Ms[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, Nghost);,
+                 Ms[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, Nghost););
 
     std::array< MultiFab, AMREX_SPACEDIM > exchange;
     AMREX_D_TERM(exchange[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -362,10 +362,6 @@ void main_main ()
           amrex::ParallelFor( tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
           {
 
-             H_bias_xface(i,j,k,0) = 0._rt;         
-             H_bias_xface(i,j,k,1) = 3.7e4;
-             H_bias_xface(i,j,k,2) = 0._rt;
-
              if (Ms_xface_arr(i,j,k) > 0._rt)
              {
 
@@ -378,12 +374,20 @@ void main_main ()
                 M_xface(i,j,k,1) = 0._rt;
                 M_xface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
 
+                H_bias_xface(i,j,k,0) = 0._rt;         
+                H_bias_xface(i,j,k,1) = 3.7e4;
+                H_bias_xface(i,j,k,2) = 0._rt;
+
              } else {
              
                 //x_face 
                 M_xface(i,j,k,0) = 0.0; 
                 M_xface(i,j,k,1) = 0.0;
                 M_xface(i,j,k,2) = 0.0;
+
+                H_bias_xface(i,j,k,0) = 0.0;         
+                H_bias_xface(i,j,k,1) = 0.0;
+                H_bias_xface(i,j,k,2) = 0.0;
 
 	     }
  
@@ -392,10 +396,6 @@ void main_main ()
 
           amrex::ParallelFor( tby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
           {
-
-             H_bias_yface(i,j,k,0) = 0._rt;         
-             H_bias_yface(i,j,k,1) = 3.7e4;
-             H_bias_yface(i,j,k,2) = 0._rt;
 
              if (Ms_yface_arr(i,j,k) > 0._rt)
              {
@@ -409,6 +409,10 @@ void main_main ()
                 M_yface(i,j,k,1) = 0._rt;
                 M_yface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
 
+                H_bias_yface(i,j,k,0) = 0._rt;         
+                H_bias_yface(i,j,k,1) = 3.7e4;
+                H_bias_yface(i,j,k,2) = 0._rt;
+
              } else {
              
                 //y_face
@@ -416,16 +420,16 @@ void main_main ()
                 M_yface(i,j,k,1) = 0.0;
                 M_yface(i,j,k,2) = 0.0;
 
+                H_bias_yface(i,j,k,0) = 0.0;         
+                H_bias_yface(i,j,k,1) = 0.0;
+                H_bias_yface(i,j,k,2) = 0.0;
+
 	     }
 
           });
 
           amrex::ParallelFor( tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
           {
-
-             H_bias_zface(i,j,k,0) = 0._rt;         
-             H_bias_zface(i,j,k,1) = 3.7e4;
-             H_bias_zface(i,j,k,2) = 0._rt;
 
              if (Ms_zface_arr(i,j,k) > 0._rt)
              {
@@ -439,12 +443,20 @@ void main_main ()
                 M_zface(i,j,k,1) = 0._rt;
                 M_zface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
 
+                H_bias_zface(i,j,k,0) = 0._rt;         
+                H_bias_zface(i,j,k,1) = 3.7e4;
+                H_bias_zface(i,j,k,2) = 0._rt;
+
              } else {
              
                 //z_face
                 M_zface(i,j,k,0) = 0.0;
                 M_zface(i,j,k,1) = 0.0;
                 M_zface(i,j,k,2) = 0.0;
+
+                H_bias_zface(i,j,k,0) = 0.0;         
+                H_bias_zface(i,j,k,1) = 0.0;
+                H_bias_zface(i,j,k,2) = 0.0;
 
 	     }
 
@@ -557,7 +569,7 @@ void main_main ()
                                                 "Hx_bias_xface", "Hx_bias_yface", "Hx_bias_zface",
                                                 "Hy_bias_xface", "Hy_bias_yface", "Hy_bias_zface",
                                                 "Hz_bias_xface", "Hz_bias_yface", "Hz_bias_zface"},
-                                                 geom, time, 0);
+                                                 geom, time, step);
 
     }
 /*
@@ -802,9 +814,9 @@ void main_main ()
                       amrex::Real Ms_hi_z = Ms_yface_arr(i, j, k+1);
 
 		      //if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0));
-                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0);
-                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 0);
-                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 0);
+                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 1);
+                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 1);
+                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 1);
 
                     }
                  
@@ -921,9 +933,9 @@ void main_main ()
                       amrex::Real Ms_hi_z = Ms_zface_arr(i, j, k+1);
 
 		      //if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0));
-                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0);
-                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 0);
-                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 0);
+                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 2);
+                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 2);
+                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 2);
 
                     }
                  

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -264,7 +264,7 @@ void main_main ()
     MultiFab PoissonRHS(ba, dm, 1, 0);
     MultiFab PoissonPhi(ba, dm, 1, 1);
 
-    MultiFab Plt(ba, dm, 21, 1);
+    MultiFab Plt(ba, dm, 21, 0);
 
     //Solver for Poisson equation
     LPInfo info;
@@ -489,7 +489,7 @@ void main_main ()
         for (MFIter mfi(Plt); mfi.isValid(); ++mfi)
         {
         
-              const Box& bx = mfi.growntilebox(1); 
+              const Box& bx = mfi.tilebox(); 
 
         // extract field data
               Array4<Real> const &M_xface = Mfield[0].array(mfi);         
@@ -1045,15 +1045,14 @@ void main_main ()
         time = time + dt;
 
         // Write a plotfile of the initial data if plot_int > 0
-        if (plot_int > 0)
+        if (plot_int > 0 && step%plot_int == 0)
         {
-            int step = 0;
             const std::string& pltfile = amrex::Concatenate("plt",step,8);
             //Averaging face-centerd Multifabs to cell-centers for plotting 
             for (MFIter mfi(Plt); mfi.isValid(); ++mfi)
             {
             
-                  const Box& bx = mfi.growntilebox(1); 
+                  const Box& bx = mfi.tilebox(); 
 
             // extract field data
                   Array4<Real> const &M_xface = Mfield[0].array(mfi);         

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -194,16 +194,16 @@ void main_main ()
     // Allocate multifabs
 
     Array<MultiFab, AMREX_SPACEDIM> Mfield;
-    for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
-    {
-        Mfield[dir].define(ba, dm, Ncomp, Nghost);
-    }
+    // face-centered Mfield
+    AMREX_D_TERM(Mfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
+                 Mfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
+                 Mfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
 
     Array<MultiFab, AMREX_SPACEDIM> Mfield_old;
-    for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
-    {
-        Mfield_old[dir].define(ba, dm, Ncomp, Nghost);
-    }
+    // face-centered Mfield_old
+    AMREX_D_TERM(Mfield_old[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
+                 Mfield_old[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
+                 Mfield_old[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
 
     Array<MultiFab, AMREX_SPACEDIM> Hfield;
     for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
@@ -217,11 +217,31 @@ void main_main ()
         H_biasfield[dir].define(ba, dm, Ncomp, Nghost);
     }
 
-    MultiFab alpha(ba, dm, Ncomp, Nghost);
-    MultiFab gamma(ba, dm, Ncomp, Nghost);
-    MultiFab Ms(ba, dm, Ncomp, Nghost);
-    MultiFab exchange(ba, dm, Ncomp, Nghost);
-    MultiFab anisotropy(ba, dm, Ncomp, Nghost);
+    //Face-centered magnetic properties
+    std::array< MultiFab, AMREX_SPACEDIM > alpha;
+    AMREX_D_TERM(alpha[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
+                 alpha[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
+                 alpha[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
+
+    std::array< MultiFab, AMREX_SPACEDIM > gamma;
+    AMREX_D_TERM(gamma[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
+                 gamma[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
+                 gamma[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
+
+    std::array< MultiFab, AMREX_SPACEDIM > Ms;
+    AMREX_D_TERM(Ms[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
+                 Ms[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
+                 Ms[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
+
+    std::array< MultiFab, AMREX_SPACEDIM > exchange;
+    AMREX_D_TERM(exchange[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
+                 exchange[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
+                 exchange[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
+
+    std::array< MultiFab, AMREX_SPACEDIM > anisotropy;
+    AMREX_D_TERM(anisotropy[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
+                 anisotropy[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 0);,
+                 anisotropy[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
 
     amrex::Print() << "==================== Initial Setup ====================\n";
     amrex::Print() << " demag_coupling      = " << demag_coupling      << "\n";
@@ -238,7 +258,7 @@ void main_main ()
     MultiFab PoissonRHS(ba, dm, 1, 0);
     MultiFab PoissonPhi(ba, dm, 1, 1);
 
-    MultiFab Plt(ba, dm, 11, 0);
+    MultiFab Plt(ba, dm, 15, 0);
 
     //Solver for Poisson equation
     LPInfo info;
@@ -312,9 +332,9 @@ void main_main ()
           const Box& bx = mfi.growntilebox(1); 
 
     // extract field data
-          Array4<Real> const &Mx = Mfield[0].array(mfi);         
-          Array4<Real> const &My = Mfield[1].array(mfi);         
-          Array4<Real> const &Mz = Mfield[2].array(mfi);
+          Array4<Real> const &M_xface = Mfield[0].array(mfi);         
+          Array4<Real> const &M_yface = Mfield[1].array(mfi);         
+          Array4<Real> const &M_zface = Mfield[2].array(mfi);
          
           Array4<Real> const &Hx_bias = H_biasfield[0].array(mfi);
           Array4<Real> const &Hy_bias = H_biasfield[1].array(mfi);
@@ -324,8 +344,14 @@ void main_main ()
           Array4<Real> const &Hy = Hfield[1].array(mfi);
           Array4<Real> const &Hz = Hfield[2].array(mfi);
               
-          const Array4<Real>& Ms_arr = Ms.array(mfi);
+          const Array4<Real>& Ms_xface_arr = Ms[0].array(mfi);
+          const Array4<Real>& Ms_yface_arr = Ms[1].array(mfi);
+          const Array4<Real>& Ms_zface_arr = Ms[2].array(mfi);
 
+          // extract tileboxes for which to loop
+          Box const &tbx = mfi.tilebox(Mfield[0].ixType().toIntVect());
+          Box const &tby = mfi.tilebox(Mfield[1].ixType().toIntVect());
+          Box const &tbz = mfi.tilebox(Mfield[2].ixType().toIntVect());
 
           amrex::ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
           {
@@ -334,24 +360,6 @@ void main_main ()
              Hz_bias(i,j,k) = 0._rt;
 
 
-             if (Ms_arr(i,j,k) > 0._rt)
-             {
-
-//               Mx(i,j,k) = 1.4e5;
-//               My(i,j,k) = 0.;
-//               Mz(i,j,k) = 0.;
-                Real x = prob_lo[0] + (i+0.5) * dx[0];
-                Real y = prob_lo[1] + (j+0.5) * dx[1];
-                Real z = prob_lo[2] + (k+0.5) * dx[2];
-                
-                Mx(i,j,k) = (y < 0) ? 1.4e5 : 0.;
-                My(i,j,k) = 0._rt;
-                Mz(i,j,k) = (y >= 0) ? 1.4e5 : 0.;
-             } else {
-                Mx(i,j,k) = 0.0;
-                My(i,j,k) = 0.0;
-                Mz(i,j,k) = 0.0;
-	     }
 
              if(demag_coupling == 1)
              { 
@@ -376,6 +384,81 @@ void main_main ()
              }
           });
 
+          amrex::ParallelFor( tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+          {
+             if (Ms_xface_arr(i,j,k) > 0._rt)
+             {
+
+                Real x = prob_lo[0] + i * dx[0];
+                Real y = prob_lo[1] + (j+0.5) * dx[1];
+                Real z = prob_lo[2] + (k+0.5) * dx[2];
+               
+                //x_face 
+                M_xface(i,j,k,0) = (y < 0) ? 1.4e5 : 0.;
+                M_xface(i,j,k,1) = 0._rt;
+                M_xface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
+
+             } else {
+             
+                //x_face 
+                M_xface(i,j,k,0) = 0.0; 
+                M_xface(i,j,k,1) = 0.0;
+                M_xface(i,j,k,2) = 0.0;
+
+	     }
+
+          });
+
+          amrex::ParallelFor( tby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+          {
+             if (Ms_yface_arr(i,j,k) > 0._rt)
+             {
+
+                Real x = prob_lo[0] + (i+0.5) * dx[0];
+                Real y = prob_lo[1] + j * dx[1];
+                Real z = prob_lo[2] + (k+0.5) * dx[2];
+               
+                //y_face
+                M_yface(i,j,k,0) = (y < 0) ? 1.4e5 : 0.;
+                M_yface(i,j,k,1) = 0._rt;
+                M_yface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
+
+             } else {
+             
+                //y_face
+                M_yface(i,j,k,0) = 0.0;
+                M_yface(i,j,k,1) = 0.0;
+                M_yface(i,j,k,2) = 0.0;
+
+	     }
+
+          });
+
+          amrex::ParallelFor( tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+          {
+             if (Ms_zface_arr(i,j,k) > 0._rt)
+             {
+
+                Real x = prob_lo[0] + (i+0.5) * dx[0];
+                Real y = prob_lo[1] + (j+0.5) * dx[1];
+                Real z = prob_lo[2] + k * dx[2];
+               
+                //z_face
+                M_zface(i,j,k,0) = (y < 0) ? 1.4e5 : 0.;
+                M_zface(i,j,k,1) = 0._rt;
+                M_zface(i,j,k,2) = (y >= 0) ? 1.4e5 : 0.;
+
+             } else {
+             
+                //z_face
+                M_zface(i,j,k,0) = 0.0;
+                M_zface(i,j,k,1) = 0.0;
+                M_zface(i,j,k,2) = 0.0;
+
+	     }
+
+          });
+
     } 
  
     // Write a plotfile of the initial data if plot_int > 0
@@ -383,18 +466,22 @@ void main_main ()
     {
         int step = 0;
         const std::string& pltfile = amrex::Concatenate("plt",step,8);
-        MultiFab::Copy(Plt, alpha, 0, 0, 1, 0);  
-        MultiFab::Copy(Plt, Ms, 0, 1, 1, 0);
-        MultiFab::Copy(Plt, gamma, 0, 2, 1, 0);
-        MultiFab::Copy(Plt, exchange, 0, 3, 1, 0);
-        MultiFab::Copy(Plt, anisotropy, 0, 4, 1, 0);
-        MultiFab::Copy(Plt, Mfield[0], 0, 5, 1, 0);
+        MultiFab::Copy(Plt, Ms[0], 0, 0, 1, 0);
+        MultiFab::Copy(Plt, Ms[1], 0, 1, 1, 0);
+        MultiFab::Copy(Plt, Ms[2], 0, 2, 1, 0);
+        MultiFab::Copy(Plt, Mfield[0], 0, 3, 1, 0);
+        MultiFab::Copy(Plt, Mfield[0], 1, 4, 1, 0);
+        MultiFab::Copy(Plt, Mfield[0], 2, 5, 1, 0);
         MultiFab::Copy(Plt, Mfield[1], 0, 6, 1, 0);
-        MultiFab::Copy(Plt, Mfield[2], 0, 7, 1, 0);
-        MultiFab::Copy(Plt, H_biasfield[0], 0, 8, 1, 0);
-        MultiFab::Copy(Plt, H_biasfield[1], 0, 9, 1, 0);
-        MultiFab::Copy(Plt, H_biasfield[2], 0, 10, 1, 0);
-        WriteSingleLevelPlotfile(pltfile, Plt, {"alpha","Ms","gamma","exchange","anisotropy","Mx", "My", "Mz", "Hx_bias", "Hy_bias", "Hz_bias"}, geom, time, 0);
+        MultiFab::Copy(Plt, Mfield[1], 1, 7, 1, 0);
+        MultiFab::Copy(Plt, Mfield[1], 2, 8, 1, 0);
+        MultiFab::Copy(Plt, Mfield[2], 0, 9, 1, 0);
+        MultiFab::Copy(Plt, Mfield[2], 1, 10, 1, 0);
+        MultiFab::Copy(Plt, Mfield[2], 2, 11, 1, 0);
+        MultiFab::Copy(Plt, H_biasfield[0], 0, 12, 1, 0);
+        MultiFab::Copy(Plt, H_biasfield[1], 0, 13, 1, 0);
+        MultiFab::Copy(Plt, H_biasfield[2], 0, 14, 1, 0);
+        WriteSingleLevelPlotfile(pltfile, Plt, {"Ms_xface","Ms_yface","Ms_zface","Mx_xface","My_xface","Mz_xface", "Mx_yface", "My_yface", "Mz_yface", "Mx_zface", "My_zface", "Mz_zface", "Hx_bias", "Hy_bias", "Hz_bias"}, geom, time, 0);
     }
 
     for (int step = 1; step <= nsteps; ++step)
@@ -402,7 +489,7 @@ void main_main ()
         // copy new solution into old solution
         for(int comp = 0; comp < 3; comp++)
         {
-           MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 1, 1);
+           MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, 1);
 
            // fill periodic ghost cells
            Mfield_old[comp].FillBoundary(geom.periodicity());
@@ -424,25 +511,46 @@ void main_main ()
               Array4<Real> const &Hx = Hfield[0].array(mfi);
               Array4<Real> const &Hy = Hfield[1].array(mfi);
               Array4<Real> const &Hz = Hfield[2].array(mfi);
-              Array4<Real> const &Mx = Mfield[0].array(mfi);         
-              Array4<Real> const &My = Mfield[1].array(mfi);         
-              Array4<Real> const &Mz = Mfield[2].array(mfi);         
-              Array4<Real> const &Mx_old = Mfield_old[0].array(mfi); 
-              Array4<Real> const &My_old = Mfield_old[1].array(mfi); 
-              Array4<Real> const &Mz_old = Mfield_old[2].array(mfi); 
+              Array4<Real> const &M_xface = Mfield[0].array(mfi);         
+              Array4<Real> const &M_yface = Mfield[1].array(mfi);         
+              Array4<Real> const &M_zface = Mfield[2].array(mfi);         
+              Array4<Real> const &M_xface_old = Mfield_old[0].array(mfi); 
+              Array4<Real> const &M_yface_old = Mfield_old[1].array(mfi); 
+              Array4<Real> const &M_zface_old = Mfield_old[2].array(mfi); 
               Array4<Real> const &Hx_bias = H_biasfield[0].array(mfi);
               Array4<Real> const &Hy_bias = H_biasfield[1].array(mfi);
               Array4<Real> const &Hz_bias = H_biasfield[2].array(mfi);
           
-              const Array4<Real>& alpha_arr = alpha.array(mfi);
-              const Array4<Real>& gamma_arr = gamma.array(mfi);
-              const Array4<Real>& Ms_arr = Ms.array(mfi);
-              const Array4<Real>& exchange_arr = exchange.array(mfi);
-              const Array4<Real>& anisotropy_arr = anisotropy.array(mfi);
- 
-              amrex::ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+              const Array4<Real>& alpha_xface_arr = alpha[0].array(mfi);
+              const Array4<Real>& alpha_yface_arr = alpha[1].array(mfi);
+              const Array4<Real>& alpha_zface_arr = alpha[2].array(mfi);
+
+              const Array4<Real>& gamma_xface_arr = gamma[0].array(mfi);
+              const Array4<Real>& gamma_yface_arr = gamma[1].array(mfi);
+              const Array4<Real>& gamma_zface_arr = gamma[2].array(mfi);
+
+              const Array4<Real>& Ms_xface_arr = Ms[0].array(mfi);
+              const Array4<Real>& Ms_yface_arr = Ms[1].array(mfi);
+              const Array4<Real>& Ms_zface_arr = Ms[2].array(mfi);
+
+              const Array4<Real>& exchange_xface_arr = exchange[0].array(mfi);
+              const Array4<Real>& exchange_yface_arr = exchange[1].array(mfi);
+              const Array4<Real>& exchange_zface_arr = exchange[2].array(mfi);
+
+              const Array4<Real>& anisotropy_xface_arr = anisotropy[0].array(mfi);
+              const Array4<Real>& anisotropy_yface_arr = anisotropy[1].array(mfi);
+              const Array4<Real>& anisotropy_zface_arr = anisotropy[2].array(mfi);
+
+
+              // extract tileboxes for which to loop
+              Box const &tbx = mfi.tilebox(Mfield[0].ixType().toIntVect());
+              Box const &tby = mfi.tilebox(Mfield[1].ixType().toIntVect());
+              Box const &tbz = mfi.tilebox(Mfield[2].ixType().toIntVect());
+
+              //xface 
+              amrex::ParallelFor( tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
               {
-                 if (Ms_arr(i,j,k) > 0._rt)
+                 if (Ms_xface_arr(i,j,k) > 0._rt)
                  {
                     amrex::Real Hx_eff = Hx_bias(i,j,k);
                     amrex::Real Hy_eff = Hy_bias(i,j,k);
@@ -458,22 +566,22 @@ void main_main ()
                     if(exchange_coupling == 1)
                     { 
                     //Add exchange term
-                      if (exchange_arr(i,j,k) == 0._rt) amrex::Abort("The exchange_arr(i,j,k) is 0.0 while including the exchange coupling term H_exchange for H_eff");
+                      if (exchange_xface_arr(i,j,k) == 0._rt) amrex::Abort("The exchange_yface_arr(i,j,k) is 0.0 while including the exchange coupling term H_exchange for H_eff");
 
                       // H_exchange - use M^(old_time)
-                      amrex::Real const H_exchange_coeff = 2.0 * exchange_arr(i,j,k) / mu0 / Ms_arr(i,j,k) / Ms_arr(i,j,k);
+                      amrex::Real const H_exchange_coeff = 2.0 * exchange_xface_arr(i,j,k) / mu0 / Ms_xface_arr(i,j,k) / Ms_xface_arr(i,j,k);
 
-                      amrex::Real Ms_lo_x = Ms_arr(i-1, j, k); 
-                      amrex::Real Ms_hi_x = Ms_arr(i+1, j, k); 
-                      amrex::Real Ms_lo_y = Ms_arr(i, j-1, k); 
-                      amrex::Real Ms_hi_y = Ms_arr(i, j+1, k); 
-                      amrex::Real Ms_lo_z = Ms_arr(i, j, k-1);
-                      amrex::Real Ms_hi_z = Ms_arr(i, j, k+1);
+                      amrex::Real Ms_lo_x = Ms_xface_arr(i-1, j, k); 
+                      amrex::Real Ms_hi_x = Ms_xface_arr(i+1, j, k); 
+                      amrex::Real Ms_lo_y = Ms_xface_arr(i, j-1, k); 
+                      amrex::Real Ms_hi_y = Ms_xface_arr(i, j+1, k); 
+                      amrex::Real Ms_lo_z = Ms_xface_arr(i, j, k-1);
+                      amrex::Real Ms_hi_z = Ms_xface_arr(i, j, k+1);
 
-		      if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(Mx_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx));
-                      Hx_eff += H_exchange_coeff * Laplacian_Mag(Mx_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx);
-                      Hy_eff += H_exchange_coeff * Laplacian_Mag(My_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx);
-                      Hz_eff += H_exchange_coeff * Laplacian_Mag(Mz_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx);
+		      //if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(M_xface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0));
+                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_xface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0);
+                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_xface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 0);
+                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_xface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 0);
 
                     }
                  
@@ -481,12 +589,14 @@ void main_main ()
                     {
                      //Add anisotropy term
  
-                     if (anisotropy_arr(i,j,k) == 0._rt) amrex::Abort("The anisotropy_arr(i,j,k) is 0.0 while including the anisotropy coupling term H_anisotropy for H_eff");
+                     if (anisotropy_xface_arr(i,j,k) == 0._rt) amrex::Abort("The anisotropy_xface_arr(i,j,k) is 0.0 while including the anisotropy coupling term H_anisotropy for H_eff");
 
                       // H_anisotropy - use M^(old_time)
                       amrex::Real M_dot_anisotropy_axis = 0.0;
-                      M_dot_anisotropy_axis = Mx(i, j, k) * anisotropy_axis[0] + My(i, j, k) * anisotropy_axis[1] + Mz(i, j, k) * anisotropy_axis[2];
-                      amrex::Real const H_anisotropy_coeff = - 2.0 * anisotropy_arr(i,j,k) / mu0 / Ms_arr(i,j,k) / Ms_arr(i,j,k);
+                      for (int comp=0; comp<3; ++comp) {
+                          M_dot_anisotropy_axis += M_xface_old(i, j, k, comp) * anisotropy_axis[comp];
+                      }
+                      amrex::Real const H_anisotropy_coeff = - 2.0 * anisotropy_xface_arr(i,j,k) / mu0 / Ms_xface_arr(i,j,k) / Ms_xface_arr(i,j,k);
                       Hx_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[0];
                       Hy_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[1];
                       Hz_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[2];
@@ -495,33 +605,30 @@ void main_main ()
 
                    //Update M
 
-                   amrex::Real mag_gammaL = gamma_arr(i,j,k) / (1._rt + std::pow(alpha_arr(i,j,k), 2._rt));
+                   amrex::Real mag_gammaL = gamma_xface_arr(i,j,k) / (1._rt + std::pow(alpha_xface_arr(i,j,k), 2._rt));
 
-                   // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s 
-                   amrex::Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(Mx(i, j, k), 2._rt) + std::pow(My(i, j, k), 2._rt) + std::pow(Mz(i, j, k), 2._rt))
-                                                             : Ms_arr(i,j,k);
-                   amrex::Real Gil_damp = mu0 * mag_gammaL * alpha_arr(i,j,k) / M_magnitude;
+                   // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
+                   amrex::Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_xface(i, j, k, 0), 2._rt) + std::pow(M_xface(i, j, k, 1), 2._rt) + std::pow(M_xface(i, j, k, 2), 2._rt))
+                                                              : Ms_xface_arr(i,j,k); 
+                   amrex::Real Gil_damp = mu0 * mag_gammaL * alpha_xface_arr(i,j,k) / M_magnitude;
 
-                   // x component on cell-centers
-                   Mx(i, j, k) += dt * (mu0 * mag_gammaL) * (My_old(i, j, k) * Hz_eff - Mz_old(i, j, k) * Hy_eff)
-                                        + dt * Gil_damp * (My_old(i, j, k) * (Mx_old(i, j, k) * Hy_eff - My_old(i, j, k) * Hx_eff)
-                                        - Mz_old(i, j, k) * (Mz_old(i, j, k) * Hx_eff - Mx_old(i, j, k) * Hz_eff));
+                   // x component on x-faces of grid
+                    M_xface(i, j, k, 0) += dt * (mu0 * mag_gammaL) * (M_xface_old(i, j, k, 1) * Hz_eff - M_xface_old(i, j, k, 2) * Hy_eff)
+                                         + dt * Gil_damp * (M_xface_old(i, j, k, 1) * (M_xface_old(i, j, k, 0) * Hy_eff - M_xface_old(i, j, k, 1) * Hx_eff)
+                                         - M_xface_old(i, j, k, 2) * (M_xface_old(i, j, k, 2) * Hx_eff - M_xface_old(i, j, k, 0) * Hz_eff));
 
-                   // y component on cell-centers
-                   My(i, j, k) += dt * (mu0 * mag_gammaL) * (Mz_old(i, j, k) * Hx_eff - Mx_old(i, j, k) * Hz_eff)
-                                        + dt * Gil_damp * (Mz_old(i, j, k) * (My_old(i, j, k) * Hz_eff - Mz_old(i, j, k) * Hy_eff)
-                                        - Mx_old(i, j, k) * (Mx_old(i, j, k) * Hy_eff - My_old(i, j, k) * Hx_eff));
+                    // y component on x-faces of grid
+                    M_xface(i, j, k, 1) += dt * (mu0 * mag_gammaL) * (M_xface_old(i, j, k, 2) * Hx_eff - M_xface_old(i, j, k, 0) * Hz_eff)
+                                         + dt * Gil_damp * (M_xface_old(i, j, k, 2) * (M_xface_old(i, j, k, 1) * Hz_eff - M_xface_old(i, j, k, 2) * Hy_eff)
+                                         - M_xface_old(i, j, k, 0) * (M_xface_old(i, j, k, 0) * Hy_eff - M_xface_old(i, j, k, 1) * Hx_eff));
 
-                   // z component on cell-centers
-                   Mz(i, j, k) += dt * (mu0 * mag_gammaL) * (Mx_old(i, j, k) * Hy_eff - My_old(i, j, k) * Hx_eff)
-                                        + dt * Gil_damp * (Mx_old(i, j, k) * (Mz_old(i, j, k) * Hx_eff - Mx_old(i, j, k) * Hz_eff)
-                                        - My_old(i, j, k) * (My_old(i, j, k) * Hz_eff - Mz_old(i, j, k) * Hy_eff));
-  
+                    // z component on x-faces of grid
+                    M_xface(i, j, k, 2) += dt * (mu0 * mag_gammaL) * (M_xface_old(i, j, k, 0) * Hy_eff - M_xface_old(i, j, k, 1) * Hx_eff)
+                                         + dt * Gil_damp * (M_xface_old(i, j, k, 0) * (M_xface_old(i, j, k, 2) * Hx_eff - M_xface_old(i, j, k, 0) * Hz_eff)
+                                         - M_xface_old(i, j, k, 1) * (M_xface_old(i, j, k, 1) * Hz_eff - M_xface_old(i, j, k, 2) * Hy_eff));
 
                    // temporary normalized magnitude of M_xface field at the fixed point
-                   amrex::Real M_magnitude_normalized = std::sqrt(std::pow(Mx(i, j, k), 2._rt) + std::pow(My(i, j, k), 2._rt) + std::pow(Mz(i, j, k), 2._rt)) / Ms_arr(i,j,k);
-
-                       
+                   amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_xface(i, j, k, 0), 2._rt) + std::pow(M_xface(i, j, k, 1), 2._rt) + std::pow(M_xface(i, j, k, 2), 2._rt)) / Ms_xface_arr(i,j,k);
                    amrex::Real normalized_error = 0.1;
 
                    if (M_normalization > 0)
@@ -534,9 +641,9 @@ void main_main ()
                            amrex::Abort("Exceed the normalized error of the Mx field");
                        }
                        // normalize the M field
-                       Mx(i, j, k) /= M_magnitude_normalized;
-                       My(i, j, k) /= M_magnitude_normalized;
-                       Mz(i, j, k) /= M_magnitude_normalized;
+                       M_xface(i, j, k, 0) /= M_magnitude_normalized;
+                       M_xface(i, j, k, 1) /= M_magnitude_normalized;
+                       M_xface(i, j, k, 2) /= M_magnitude_normalized;
                    }
                    else if (M_normalization == 0)
                    {   
@@ -549,9 +656,247 @@ void main_main ()
                        else if (M_magnitude_normalized > 1._rt && M_magnitude_normalized <= (1._rt + normalized_error) )
                        {
                            // normalize the M field
-                           Mx(i, j, k) /= M_magnitude_normalized;
-                           My(i, j, k) /= M_magnitude_normalized;
-                           Mz(i, j, k) /= M_magnitude_normalized;
+                           M_xface(i, j, k, 0) /= M_magnitude_normalized;
+                           M_xface(i, j, k, 1) /= M_magnitude_normalized;
+                           M_xface(i, j, k, 2) /= M_magnitude_normalized;
+                       }
+                   }
+
+                 }   
+ 
+              });     
+                      
+              //yface 
+              amrex::ParallelFor( tby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+              {
+                 if (Ms_yface_arr(i,j,k) > 0._rt)
+                 {
+                    amrex::Real Hx_eff = Hx_bias(i,j,k);
+                    amrex::Real Hy_eff = Hy_bias(i,j,k);
+                    amrex::Real Hz_eff = Hz_bias(i,j,k);
+                 
+                    if(demag_coupling == 1)
+                    {
+                      Hx_eff += Hx(i,j,k);
+                      Hy_eff += Hy(i,j,k);
+                      Hz_eff += Hz(i,j,k);
+                    }
+
+                    if(exchange_coupling == 1)
+                    { 
+                    //Add exchange term
+                      if (exchange_yface_arr(i,j,k) == 0._rt) amrex::Abort("The exchange_yface_arr(i,j,k) is 0.0 while including the exchange coupling term H_exchange for H_eff");
+
+                      // H_exchange - use M^(old_time)
+                      amrex::Real const H_exchange_coeff = 2.0 * exchange_yface_arr(i,j,k) / mu0 / Ms_yface_arr(i,j,k) / Ms_yface_arr(i,j,k);
+
+                      amrex::Real Ms_lo_x = Ms_yface_arr(i-1, j, k); 
+                      amrex::Real Ms_hi_x = Ms_yface_arr(i+1, j, k); 
+                      amrex::Real Ms_lo_y = Ms_yface_arr(i, j-1, k); 
+                      amrex::Real Ms_hi_y = Ms_yface_arr(i, j+1, k); 
+                      amrex::Real Ms_lo_z = Ms_yface_arr(i, j, k-1);
+                      amrex::Real Ms_hi_z = Ms_yface_arr(i, j, k+1);
+
+		      //if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0));
+                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0);
+                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 0);
+                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_yface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 0);
+
+                    }
+                 
+                    if(anisotropy_coupling == 1)
+                    {
+                     //Add anisotropy term
+ 
+                     if (anisotropy_yface_arr(i,j,k) == 0._rt) amrex::Abort("The anisotropy_yface_arr(i,j,k) is 0.0 while including the anisotropy coupling term H_anisotropy for H_eff");
+
+                      // H_anisotropy - use M^(old_time)
+                      amrex::Real M_dot_anisotropy_axis = 0.0;
+                      for (int comp=0; comp<3; ++comp) {
+                          M_dot_anisotropy_axis += M_yface_old(i, j, k, comp) * anisotropy_axis[comp];
+                      }
+                      amrex::Real const H_anisotropy_coeff = - 2.0 * anisotropy_yface_arr(i,j,k) / mu0 / Ms_yface_arr(i,j,k) / Ms_yface_arr(i,j,k);
+                      Hx_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[0];
+                      Hy_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[1];
+                      Hz_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[2];
+
+                    }
+
+                   //Update M
+
+                   amrex::Real mag_gammaL = gamma_yface_arr(i,j,k) / (1._rt + std::pow(alpha_yface_arr(i,j,k), 2._rt));
+
+                   // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
+                   amrex::Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_yface(i, j, k, 0), 2._rt) + std::pow(M_yface(i, j, k, 1), 2._rt) + std::pow(M_yface(i, j, k, 2), 2._rt))
+                                                              : Ms_yface_arr(i,j,k); 
+                   amrex::Real Gil_damp = mu0 * mag_gammaL * alpha_yface_arr(i,j,k) / M_magnitude;
+
+                   // x component on y-faces of grid
+                    M_yface(i, j, k, 0) += dt * (mu0 * mag_gammaL) * (M_yface_old(i, j, k, 1) * Hz_eff - M_yface_old(i, j, k, 2) * Hy_eff)
+                                         + dt * Gil_damp * (M_yface_old(i, j, k, 1) * (M_yface_old(i, j, k, 0) * Hy_eff - M_yface_old(i, j, k, 1) * Hx_eff)
+                                         - M_yface_old(i, j, k, 2) * (M_yface_old(i, j, k, 2) * Hx_eff - M_yface_old(i, j, k, 0) * Hz_eff));
+
+                    // y component on y-faces of grid
+                    M_yface(i, j, k, 1) += dt * (mu0 * mag_gammaL) * (M_yface_old(i, j, k, 2) * Hx_eff - M_yface_old(i, j, k, 0) * Hz_eff)
+                                         + dt * Gil_damp * (M_yface_old(i, j, k, 2) * (M_yface_old(i, j, k, 1) * Hz_eff - M_yface_old(i, j, k, 2) * Hy_eff)
+                                         - M_yface_old(i, j, k, 0) * (M_yface_old(i, j, k, 0) * Hy_eff - M_yface_old(i, j, k, 1) * Hx_eff));
+
+                    // z component on y-faces of grid
+                    M_yface(i, j, k, 2) += dt * (mu0 * mag_gammaL) * (M_yface_old(i, j, k, 0) * Hy_eff - M_yface_old(i, j, k, 1) * Hx_eff)
+                                         + dt * Gil_damp * (M_yface_old(i, j, k, 0) * (M_yface_old(i, j, k, 2) * Hx_eff - M_yface_old(i, j, k, 0) * Hz_eff)
+                                         - M_yface_old(i, j, k, 1) * (M_yface_old(i, j, k, 1) * Hz_eff - M_yface_old(i, j, k, 2) * Hy_eff));
+
+                   // temporary normalized magnitude of M_xface field at the fixed point
+                   amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_yface(i, j, k, 0), 2._rt) + std::pow(M_yface(i, j, k, 1), 2._rt) + std::pow(M_yface(i, j, k, 2), 2._rt)) / Ms_yface_arr(i,j,k);
+                   amrex::Real normalized_error = 0.1;
+
+                   if (M_normalization > 0)
+                   {
+                       // saturated case; if |M| has drifted from M_s too much, abort.  Otherwise, normalize
+                       // check the normalized error
+                       if (amrex::Math::abs(1._rt - M_magnitude_normalized) > normalized_error)
+                       {
+                           printf("M_magnitude_normalized = %g \n", M_magnitude_normalized);
+                           amrex::Abort("Exceed the normalized error of the Mx field");
+                       }
+                       // normalize the M field
+                       M_yface(i, j, k, 0) /= M_magnitude_normalized;
+                       M_yface(i, j, k, 1) /= M_magnitude_normalized;
+                       M_yface(i, j, k, 2) /= M_magnitude_normalized;
+                   }
+                   else if (M_normalization == 0)
+                   {   
+		       if(i == 1 && j == 1 && k == 1) printf("Here ??? \n");
+                       // check the normalized error
+                       if (M_magnitude_normalized > (1._rt + normalized_error))
+                       {
+                           amrex::Abort("Caution: Unsaturated material has M_xface exceeding the saturation magnetization");
+                       }
+                       else if (M_magnitude_normalized > 1._rt && M_magnitude_normalized <= (1._rt + normalized_error) )
+                       {
+                           // normalize the M field
+                           M_yface(i, j, k, 0) /= M_magnitude_normalized;
+                           M_yface(i, j, k, 1) /= M_magnitude_normalized;
+                           M_yface(i, j, k, 2) /= M_magnitude_normalized;
+                       }
+                   }
+
+                 }   
+ 
+              });     
+                      
+              //zface 
+              amrex::ParallelFor( tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+              {
+                 if (Ms_zface_arr(i,j,k) > 0._rt)
+                 {
+                    amrex::Real Hx_eff = Hx_bias(i,j,k);
+                    amrex::Real Hy_eff = Hy_bias(i,j,k);
+                    amrex::Real Hz_eff = Hz_bias(i,j,k);
+                 
+                    if(demag_coupling == 1)
+                    {
+                      Hx_eff += Hx(i,j,k);
+                      Hy_eff += Hy(i,j,k);
+                      Hz_eff += Hz(i,j,k);
+                    }
+
+                    if(exchange_coupling == 1)
+                    { 
+                    //Add exchange term
+                      if (exchange_zface_arr(i,j,k) == 0._rt) amrex::Abort("The exchange_zface_arr(i,j,k) is 0.0 while including the exchange coupling term H_exchange for H_eff");
+
+                      // H_exchange - use M^(old_time)
+                      amrex::Real const H_exchange_coeff = 2.0 * exchange_zface_arr(i,j,k) / mu0 / Ms_zface_arr(i,j,k) / Ms_zface_arr(i,j,k);
+
+                      amrex::Real Ms_lo_x = Ms_zface_arr(i-1, j, k); 
+                      amrex::Real Ms_hi_x = Ms_zface_arr(i+1, j, k); 
+                      amrex::Real Ms_lo_y = Ms_zface_arr(i, j-1, k); 
+                      amrex::Real Ms_hi_y = Ms_zface_arr(i, j+1, k); 
+                      amrex::Real Ms_lo_z = Ms_zface_arr(i, j, k-1);
+                      amrex::Real Ms_hi_z = Ms_zface_arr(i, j, k+1);
+
+		      //if(i == 31 && j == 31 && k == 31) printf("Laplacian_x = %g \n", Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0));
+                      Hx_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 0, 0);
+                      Hy_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 1, 0);
+                      Hz_eff += H_exchange_coeff * Laplacian_Mag(M_zface_old, Ms_lo_x, Ms_hi_x, Ms_lo_y, Ms_hi_y, Ms_lo_z, Ms_hi_z, i, j, k, dx, 2, 0);
+
+                    }
+                 
+                    if(anisotropy_coupling == 1)
+                    {
+                     //Add anisotropy term
+ 
+                     if (anisotropy_zface_arr(i,j,k) == 0._rt) amrex::Abort("The anisotropy_zface_arr(i,j,k) is 0.0 while including the anisotropy coupling term H_anisotropy for H_eff");
+
+                      // H_anisotropy - use M^(old_time)
+                      amrex::Real M_dot_anisotropy_axis = 0.0;
+                      for (int comp=0; comp<3; ++comp) {
+                          M_dot_anisotropy_axis += M_zface_old(i, j, k, comp) * anisotropy_axis[comp];
+                      }
+                      amrex::Real const H_anisotropy_coeff = - 2.0 * anisotropy_zface_arr(i,j,k) / mu0 / Ms_zface_arr(i,j,k) / Ms_zface_arr(i,j,k);
+                      Hx_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[0];
+                      Hy_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[1];
+                      Hz_eff += H_anisotropy_coeff * M_dot_anisotropy_axis * anisotropy_axis[2];
+
+                    }
+
+                   //Update M
+
+                   amrex::Real mag_gammaL = gamma_zface_arr(i,j,k) / (1._rt + std::pow(alpha_zface_arr(i,j,k), 2._rt));
+
+                   // 0 = unsaturated; compute |M| locally.  1 = saturated; use M_s
+                   amrex::Real M_magnitude = (M_normalization == 0) ? std::sqrt(std::pow(M_zface(i, j, k, 0), 2._rt) + std::pow(M_zface(i, j, k, 1), 2._rt) + std::pow(M_zface(i, j, k, 2), 2._rt))
+                                                              : Ms_zface_arr(i,j,k); 
+                   amrex::Real Gil_damp = mu0 * mag_gammaL * alpha_zface_arr(i,j,k) / M_magnitude;
+
+                   // x component on z-faces of grid
+                    M_zface(i, j, k, 0) += dt * (mu0 * mag_gammaL) * (M_zface_old(i, j, k, 1) * Hz_eff - M_zface_old(i, j, k, 2) * Hy_eff)
+                                         + dt * Gil_damp * (M_zface_old(i, j, k, 1) * (M_zface_old(i, j, k, 0) * Hy_eff - M_zface_old(i, j, k, 1) * Hx_eff)
+                                         - M_zface_old(i, j, k, 2) * (M_zface_old(i, j, k, 2) * Hx_eff - M_zface_old(i, j, k, 0) * Hz_eff));
+
+                    // y component on z-faces of grid
+                    M_zface(i, j, k, 1) += dt * (mu0 * mag_gammaL) * (M_zface_old(i, j, k, 2) * Hx_eff - M_zface_old(i, j, k, 0) * Hz_eff)
+                                         + dt * Gil_damp * (M_zface_old(i, j, k, 2) * (M_zface_old(i, j, k, 1) * Hz_eff - M_zface_old(i, j, k, 2) * Hy_eff)
+                                         - M_zface_old(i, j, k, 0) * (M_zface_old(i, j, k, 0) * Hy_eff - M_zface_old(i, j, k, 1) * Hx_eff));
+
+                    // z component on z-faces of grid
+                    M_zface(i, j, k, 2) += dt * (mu0 * mag_gammaL) * (M_zface_old(i, j, k, 0) * Hy_eff - M_zface_old(i, j, k, 1) * Hx_eff)
+                                         + dt * Gil_damp * (M_zface_old(i, j, k, 0) * (M_zface_old(i, j, k, 2) * Hx_eff - M_zface_old(i, j, k, 0) * Hz_eff)
+                                         - M_zface_old(i, j, k, 1) * (M_zface_old(i, j, k, 1) * Hz_eff - M_zface_old(i, j, k, 2) * Hy_eff));
+
+                   // temporary normalized magnitude of M_xface field at the fixed point
+                   amrex::Real M_magnitude_normalized = std::sqrt(std::pow(M_zface(i, j, k, 0), 2._rt) + std::pow(M_zface(i, j, k, 1), 2._rt) + std::pow(M_zface(i, j, k, 2), 2._rt)) / Ms_zface_arr(i,j,k);
+                   amrex::Real normalized_error = 0.1;
+
+                   if (M_normalization > 0)
+                   {
+                       // saturated case; if |M| has drifted from M_s too much, abort.  Otherwise, normalize
+                       // check the normalized error
+                       if (amrex::Math::abs(1._rt - M_magnitude_normalized) > normalized_error)
+                       {
+                           printf("M_magnitude_normalized = %g \n", M_magnitude_normalized);
+                           amrex::Abort("Exceed the normalized error of the Mx field");
+                       }
+                       // normalize the M field
+                       M_zface(i, j, k, 0) /= M_magnitude_normalized;
+                       M_zface(i, j, k, 1) /= M_magnitude_normalized;
+                       M_zface(i, j, k, 2) /= M_magnitude_normalized;
+                   }
+                   else if (M_normalization == 0)
+                   {   
+		       if(i == 1 && j == 1 && k == 1) printf("Here ??? \n");
+                       // check the normalized error
+                       if (M_magnitude_normalized > (1._rt + normalized_error))
+                       {
+                           amrex::Abort("Caution: Unsaturated material has M_xface exceeding the saturation magnetization");
+                       }
+                       else if (M_magnitude_normalized > 1._rt && M_magnitude_normalized <= (1._rt + normalized_error) )
+                       {
+                           // normalize the M field
+                           M_zface(i, j, k, 0) /= M_magnitude_normalized;
+                           M_zface(i, j, k, 1) /= M_magnitude_normalized;
+                           M_zface(i, j, k, 2) /= M_magnitude_normalized;
                        }
                    }
 
@@ -598,18 +943,22 @@ void main_main ()
         if (plot_int > 0 && step%plot_int == 0)
         {
             const std::string& pltfile = amrex::Concatenate("plt",step,8);
-            MultiFab::Copy(Plt, alpha, 0, 0, 1, 0);  
-            MultiFab::Copy(Plt, Ms, 0, 1, 1, 0);
-            MultiFab::Copy(Plt, gamma, 0, 2, 1, 0);
-            MultiFab::Copy(Plt, exchange, 0, 3, 1, 0);
-            MultiFab::Copy(Plt, anisotropy, 0, 4, 1, 0);
-            MultiFab::Copy(Plt, Mfield[0], 0, 5, 1, 0);
+            MultiFab::Copy(Plt, Ms[0], 0, 0, 1, 0);
+            MultiFab::Copy(Plt, Ms[1], 0, 1, 1, 0);
+            MultiFab::Copy(Plt, Ms[2], 0, 2, 1, 0);
+            MultiFab::Copy(Plt, Mfield[0], 0, 3, 1, 0);
+            MultiFab::Copy(Plt, Mfield[0], 1, 4, 1, 0);
+            MultiFab::Copy(Plt, Mfield[0], 2, 5, 1, 0);
             MultiFab::Copy(Plt, Mfield[1], 0, 6, 1, 0);
-            MultiFab::Copy(Plt, Mfield[2], 0, 7, 1, 0);
-            MultiFab::Copy(Plt, H_biasfield[0], 0, 8, 1, 0);
-            MultiFab::Copy(Plt, H_biasfield[1], 0, 9, 1, 0);
-            MultiFab::Copy(Plt, H_biasfield[2], 0, 10, 1, 0);
-            WriteSingleLevelPlotfile(pltfile, Plt, {"alpha","Ms","gamma","exchange","anisotropy","Mx", "My", "Mz", "Hx_bias", "Hy_bias", "Hz_bias"}, geom, time, step);
+            MultiFab::Copy(Plt, Mfield[1], 1, 7, 1, 0);
+            MultiFab::Copy(Plt, Mfield[1], 2, 8, 1, 0);
+            MultiFab::Copy(Plt, Mfield[2], 0, 9, 1, 0);
+            MultiFab::Copy(Plt, Mfield[2], 1, 10, 1, 0);
+            MultiFab::Copy(Plt, Mfield[2], 2, 11, 1, 0);
+            MultiFab::Copy(Plt, H_biasfield[0], 0, 12, 1, 0);
+            MultiFab::Copy(Plt, H_biasfield[1], 0, 13, 1, 0);
+            MultiFab::Copy(Plt, H_biasfield[2], 0, 14, 1, 0);
+            WriteSingleLevelPlotfile(pltfile, Plt, {"Ms_xface","Ms_yface","Ms_zface","Mx_xface","My_xface","Mz_xface", "Mx_yface", "My_yface", "Mz_yface", "Mx_zface", "My_zface", "Mz_zface", "Hx_bias", "Hy_bias", "Hz_bias"}, geom, time, step);
         }
 
         // MultiFab memory usage


### PR DESCRIPTION
**Steps :** 

- Create array of three  face-centered MultiFabs called `Mfield` such that each array element is a three components MultifFab.
`Mfield[0]` contains `Mx`, `My`, and `Mz` at `xface`
`Mfield[1]` contains `Mx`, `My`, and `Mz` at `yface`
`Mfield[2]` contains `Mx`, `My`, and `Mz` at `zface`
- Do the same for Mfield old.
- Extract tileboxes `tbx`, `tby`, and `tbz` for `xface`, `yface`, and `zface` MultiFabs.
- Three ParalleFors to update `Mx`, `My`, and `Mz` at `xface`, `yface`, and `zface` respectively.
- Initialize magnetic properties `(alpha, gamma, Ms, exchange, anisotropy)` on cell faces as well and use values at correct faces in M update.
- Update the Plotfile functions to accommodate these changes.

**Question:**
How to handle Hfield?