### PR TITLE
fixed M ghost cell issue

### DIFF
--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -214,9 +214,9 @@ void main_main ()
 
     Array<MultiFab, AMREX_SPACEDIM> Mfield_error;
     // face-centered Mfield at predictor step (for 2nd order time integrator)
-    AMREX_D_TERM(Mfield_error[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
-                 Mfield_error[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
-                 Mfield_error[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
+    AMREX_D_TERM(Mfield_error[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
+                 Mfield_error[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
+                 Mfield_error[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS;
     // face-centered LLG_RHS
@@ -347,7 +347,7 @@ void main_main ()
        MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Nghost);
        MultiFab::Copy(Mfield_pre[comp], Mfield[comp], 0, 0, 3, Nghost);
        MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Nghost);
-       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, Nghost);
+       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, 0);
 
        // fill periodic ghost cells
        Mfield_old[comp].FillBoundary(geom.periodicity());

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -181,7 +181,7 @@ void main_main ()
     GpuArray<Real,AMREX_SPACEDIM> dx = geom.CellSizeArray();
 
     // Nghost = number of ghost cells for each array
-    int Nghost = 1;
+    int Nghost = 2;
 
     // Ncomp = number of components for each array
     int Ncomp = 1;
@@ -223,33 +223,33 @@ void main_main ()
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
-                 LLG_RHS[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
-                 LLG_RHS[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
+    AMREX_D_TERM(LLG_RHS[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
+                 LLG_RHS[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
+                 LLG_RHS[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS_pre;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS_pre[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
-                 LLG_RHS_pre[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
-                 LLG_RHS_pre[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
+    AMREX_D_TERM(LLG_RHS_pre[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
+                 LLG_RHS_pre[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
+                 LLG_RHS_pre[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS_avg;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS_avg[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
-                 LLG_RHS_avg[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
-                 LLG_RHS_avg[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
+    AMREX_D_TERM(LLG_RHS_avg[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
+                 LLG_RHS_avg[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
+                 LLG_RHS_avg[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
 
     Array<MultiFab, AMREX_SPACEDIM> H_demagfield;
     for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
     {
-        H_demagfield[dir].define(ba, dm, Ncomp, Nghost);
+        H_demagfield[dir].define(ba, dm, Ncomp, 1);
     }
 
     Array<MultiFab, AMREX_SPACEDIM> H_biasfield;
     // face-centered H_biasfield
-    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, Nghost);,
-                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, Nghost);,
-                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, Nghost););
+    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
+                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
+                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
 
     //Face-centered magnetic properties
     std::array< MultiFab, AMREX_SPACEDIM > alpha;
@@ -263,9 +263,9 @@ void main_main ()
                  gamma[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 0););
 
     std::array< MultiFab, AMREX_SPACEDIM > Ms;
-    AMREX_D_TERM(Ms[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, Nghost);,
-                 Ms[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, Nghost);,
-                 Ms[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, Nghost););
+    AMREX_D_TERM(Ms[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 1);,
+                 Ms[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 1, 1);,
+                 Ms[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 1, 1););
 
     std::array< MultiFab, AMREX_SPACEDIM > exchange;
     AMREX_D_TERM(exchange[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 1, 0);,
@@ -347,10 +347,10 @@ void main_main ()
     // copy new solution into old solution
     for(int comp = 0; comp < 3; comp++)
     {
-       MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, 1);
-       MultiFab::Copy(Mfield_pre[comp], Mfield[comp], 0, 0, 3, 1);
-       MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, 1);
-       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, 1);
+       MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+       MultiFab::Copy(Mfield_pre[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+       MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
 
        // fill periodic ghost cells
        Mfield_old[comp].FillBoundary(geom.periodicity());
@@ -403,7 +403,7 @@ void main_main ()
            // copy new solution into old solution
            for(int comp = 0; comp < 3; comp++)
            {
-              MultiFab::Copy(Mfield_old[comp], Mfield_pre[comp], 0, 0, 3, 1);
+              MultiFab::Copy(Mfield_old[comp], Mfield_pre[comp], 0, 0, 3, Mfield_pre[comp].nGrow());
 
               // fill periodic ghost cells
               Mfield_old[comp].FillBoundary(geom.periodicity());
@@ -540,8 +540,8 @@ void main_main ()
 
 	      for(int face = 0; face < 3; face++){
  		 for(int comp = 0; comp < 3; comp++){
-		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, 1);
-		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, 1);
+		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, Mfield[face].nGrow());
+		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, Mfield_prev_iter[face].nGrow());
 		    Real M_mag_error = Mfield_error[face].norm0(comp)/Mfield[face].norm0(comp);
 		    if (M_mag_error >= M_mag_error_max){
 		       M_mag_error_max = M_mag_error;
@@ -553,7 +553,7 @@ void main_main ()
 	      // copy new solution into Mfield_pre_iter
 	      for(int comp = 0; comp < 3; comp++)
 	      {
-	         MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, 1);
+	         MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
 		 // fill periodic ghost cells
 		 Mfield_prev_iter[comp].FillBoundary(geom.periodicity());
 	      }
@@ -568,7 +568,7 @@ void main_main ()
            // copy new solution into old solution
            for (int comp = 0; comp < 3; comp++)
            {
- 	      MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, 1);
+ 	      MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
 	      // fill periodic ghost cells
 	      Mfield_old[comp].FillBoundary(geom.periodicity());
            }

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -537,8 +537,8 @@ void main_main ()
 
 	      for(int face = 0; face < 3; face++){
  		 for(int comp = 0; comp < 3; comp++){
-		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, Nghost);
-		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, Nghost);
+		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, 0);
+		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, 0);
 		    Real M_mag_error = Mfield_error[face].norm0(comp)/Mfield[face].norm0(comp);
 		    if (M_mag_error >= M_mag_error_max){
 		       M_mag_error_max = M_mag_error;

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -183,9 +183,6 @@ void main_main ()
     // Nghost = number of ghost cells for each array
     int Nghost = 2;
 
-    // Ncomp = number of components for each array
-    int Ncomp = 1;
-
     // How Boxes are distrubuted among MPI processes
     DistributionMapping dm(ba);
 
@@ -223,33 +220,33 @@ void main_main ()
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
-                 LLG_RHS[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
-                 LLG_RHS[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
+    AMREX_D_TERM(LLG_RHS[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
+                 LLG_RHS[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
+                 LLG_RHS[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS_pre;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS_pre[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
-                 LLG_RHS_pre[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
-                 LLG_RHS_pre[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
+    AMREX_D_TERM(LLG_RHS_pre[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
+                 LLG_RHS_pre[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
+                 LLG_RHS_pre[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
 
     Array<MultiFab, AMREX_SPACEDIM> LLG_RHS_avg;
     // face-centered LLG_RHS
-    AMREX_D_TERM(LLG_RHS_avg[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
-                 LLG_RHS_avg[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
-                 LLG_RHS_avg[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
+    AMREX_D_TERM(LLG_RHS_avg[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
+                 LLG_RHS_avg[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
+                 LLG_RHS_avg[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
 
     Array<MultiFab, AMREX_SPACEDIM> H_demagfield;
     for (int dir = 0; dir < AMREX_SPACEDIM; dir++)
     {
-        H_demagfield[dir].define(ba, dm, Ncomp, 1);
+        H_demagfield[dir].define(ba, dm, 1, 0);
     }
 
     Array<MultiFab, AMREX_SPACEDIM> H_biasfield;
     // face-centered H_biasfield
-    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 1);,
-                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 1);,
-                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 1););
+    AMREX_D_TERM(H_biasfield[0].define(convert(ba,IntVect(AMREX_D_DECL(1,0,0))), dm, 3, 0);,
+                 H_biasfield[1].define(convert(ba,IntVect(AMREX_D_DECL(0,1,0))), dm, 3, 0);,
+                 H_biasfield[2].define(convert(ba,IntVect(AMREX_D_DECL(0,0,1))), dm, 3, 0););
 
     //Face-centered magnetic properties
     std::array< MultiFab, AMREX_SPACEDIM > alpha;
@@ -347,10 +344,10 @@ void main_main ()
     // copy new solution into old solution
     for(int comp = 0; comp < 3; comp++)
     {
-       MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
-       MultiFab::Copy(Mfield_pre[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
-       MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
-       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+       MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Nghost);
+       MultiFab::Copy(Mfield_pre[comp], Mfield[comp], 0, 0, 3, Nghost);
+       MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Nghost);
+       MultiFab::Copy(Mfield_error[comp], Mfield[comp], 0, 0, 3, Nghost);
 
        // fill periodic ghost cells
        Mfield_old[comp].FillBoundary(geom.periodicity());
@@ -389,7 +386,7 @@ void main_main ()
 
            // M^{n+1} = M^n + dt * f^n
 	   for(int i = 0; i < 3; i++){
-	      MultiFab::LinComb(Mfield_pre[i], 1.0, Mfield_old[i], 0, dt, LLG_RHS[i], 0, 0, 3, Nghost);
+	      MultiFab::LinComb(Mfield_pre[i], 1.0, Mfield_old[i], 0, dt, LLG_RHS[i], 0, 0, 3, 0);
 	   }
 
            NormalizeM(Mfield_pre, Ms, M_normalization);
@@ -403,7 +400,7 @@ void main_main ()
            // copy new solution into old solution
            for(int comp = 0; comp < 3; comp++)
            {
-              MultiFab::Copy(Mfield_old[comp], Mfield_pre[comp], 0, 0, 3, Mfield_pre[comp].nGrow());
+              MultiFab::Copy(Mfield_old[comp], Mfield_pre[comp], 0, 0, 3, Nghost);
 
               // fill periodic ghost cells
               Mfield_old[comp].FillBoundary(geom.periodicity());
@@ -457,8 +454,8 @@ void main_main ()
 	      // Corrector step update M
 	      // M^{n+1, *} = M^n + 0.5 * dt * (f^n + f^{n+1, *})
 	      for(int i = 0; i < 3; i++){
-		MultiFab::LinComb(LLG_RHS_avg[i], 0.5, LLG_RHS[i], 0, 0.5, LLG_RHS_pre[i], 0, 0, 3, Nghost);
-		MultiFab::LinComb(Mfield[i], 1.0, Mfield_old[i], 0, dt, LLG_RHS_avg[i], 0, 0, 3, Nghost);
+		MultiFab::LinComb(LLG_RHS_avg[i], 0.5, LLG_RHS[i], 0, 0.5, LLG_RHS_pre[i], 0, 0, 3, 0);
+		MultiFab::LinComb(Mfield[i], 1.0, Mfield_old[i], 0, dt, LLG_RHS_avg[i], 0, 0, 3, 0);
 	      }
 
 	      // Normalize M              
@@ -540,8 +537,8 @@ void main_main ()
 
 	      for(int face = 0; face < 3; face++){
  		 for(int comp = 0; comp < 3; comp++){
-		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, Mfield[face].nGrow());
-		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, Mfield_prev_iter[face].nGrow());
+		    MultiFab::Copy(Mfield_error[face], Mfield[face], 0, 0, 3, Nghost);
+		    MultiFab::Subtract(Mfield_error[face], Mfield_prev_iter[face], 0, 0, 3, Nghost);
 		    Real M_mag_error = Mfield_error[face].norm0(comp)/Mfield[face].norm0(comp);
 		    if (M_mag_error >= M_mag_error_max){
 		       M_mag_error_max = M_mag_error;
@@ -553,7 +550,7 @@ void main_main ()
 	      // copy new solution into Mfield_pre_iter
 	      for(int comp = 0; comp < 3; comp++)
 	      {
-	         MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+	         MultiFab::Copy(Mfield_prev_iter[comp], Mfield[comp], 0, 0, 3, Nghost);
 		 // fill periodic ghost cells
 		 Mfield_prev_iter[comp].FillBoundary(geom.periodicity());
 	      }
@@ -568,7 +565,7 @@ void main_main ()
            // copy new solution into old solution
            for (int comp = 0; comp < 3; comp++)
            {
- 	      MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Mfield[comp].nGrow());
+ 	      MultiFab::Copy(Mfield_old[comp], Mfield[comp], 0, 0, 3, Nghost);
 	      // fill periodic ghost cells
 	      Mfield_old[comp].FillBoundary(geom.periodicity());
            }


### PR DESCRIPTION
M needs 2 ghost cells when the magnetic material interface overlaps with grid boundaries. 

The following input file include such a case that the material surface overlaps with grid boundaries when running with 64 cores, and it only works when `Nghost = 2`. If `Nghost = 1`, the simulation segfault right away complaining `amrex::Abort::17::Exceed the normalized error of the Mx field !!!`

```
n_cell = 64 64 64
max_grid_size = 16
dt = 4.0e-15
nsteps = 100
plot_int = 10

Phi_Bc_hi = 0.0
Phi_Bc_lo = 0.0

TimeIntegratorOrder = 2

prob_lo = -16.e-9 -16.e-9 -16.e-9
prob_hi =  16.e-9  16.e-9  16.e-9

mag_lo = -8.e-9 -8.e-9 -8.e-9
mag_hi =  8.e-9  8.e-9  8.e-9

mu0 = 1.25663706212e-6 
alpha_val = 0.058
Ms_val = 1.4e5
gamma_val = -1.759e11
exchange_val = 3.76e-12
anisotropy_val = -139.26
anisotropy_axis = 0.0 1.0 0.0

demag_coupling = 0
M_normalization = 1
exchange_coupling = 1
anisotropy_coupling = 0
```
Updates:
with Andy's suggested fix on ghost cell numbers for RHS multifabs, single core and multicore simulation matched:

mpiexec -n 64 ./main3d.gnu.DEBUG.MPI.ex inputs_exchange 
```
MPI initialized with 64 MPI processes
MPI initialized with thread support level 0
AMReX (22.09-117-g2219dbdca1ba-dirty) initialized
==================== Initial Setup ====================
 demag_coupling      = 0
 M_normalization     = 1
 exchange_coupling   = 1
 anisotropy_coupling = 0
 Ms                  = 140000
 alpha               = 0.058
 gamma               = -1.759e+11
 exchange_value      = 3.76e-12
 anisotropy_value    = -139.26
=======================================================
iter = 1, M_mag_error_max = 0.1489814266
iter = 2, M_mag_error_max = 0.02241954938
iter = 3, M_mag_error_max = 0.003344750653
iter = 4, M_mag_error_max = 0.0007498694073
iter = 5, M_mag_error_max = 0.0001862717924
iter = 6, M_mag_error_max = 4.384224511e-05
iter = 7, M_mag_error_max = 1.113960298e-05
iter = 8, M_mag_error_max = 2.714305802e-06
iter = 9, M_mag_error_max = 7.037668044e-07
Advanced step 1 in 1.126643004 seconds
High-water FAB megabyte spread across MPI nodes: [5 ... 5]
Curent     FAB megabyte spread across MPI nodes: [5 ... 5]
iter = 1, M_mag_error_max = 0.1355607925
iter = 2, M_mag_error_max = 0.02079223546
iter = 3, M_mag_error_max = 0.002641455299
iter = 4, M_mag_error_max = 0.0005645492217
iter = 5, M_mag_error_max = 0.0001363801193
iter = 6, M_mag_error_max = 3.412621199e-05
iter = 7, M_mag_error_max = 9.080454565e-06
iter = 8, M_mag_error_max = 2.445929319e-06
iter = 9, M_mag_error_max = 6.630928298e-07
Advanced step 2 in 1.08416999 seconds
High-water FAB megabyte spread across MPI nodes: [5 ... 5]
Curent     FAB megabyte spread across MPI nodes: [5 ... 5]
iter = 1, M_mag_error_max = 0.1076802972
iter = 2, M_mag_error_max = 0.01700277684
iter = 3, M_mag_error_max = 0.002841017099
iter = 4, M_mag_error_max = 0.0006859039837
iter = 5, M_mag_error_max = 0.0001726186096
iter = 6, M_mag_error_max = 4.34297178e-05
iter = 7, M_mag_error_max = 1.103904149e-05
iter = 8, M_mag_error_max = 2.854099255e-06
iter = 9, M_mag_error_max = 7.355508949e-07
Advanced step 3 in 1.098574167 seconds
High-water FAB megabyte spread across MPI nodes: [5 ... 5]
Curent     FAB megabyte spread across MPI nodes: [5 ... 5]
```

./main3d.gnu.DEBUG.MPI.ex inputs_exchange 
```
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (22.09-117-g2219dbdca1ba-dirty) initialized
==================== Initial Setup ====================
 demag_coupling      = 0
 M_normalization     = 1
 exchange_coupling   = 1
 anisotropy_coupling = 0
 Ms                  = 140000
 alpha               = 0.058
 gamma               = -1.759e+11
 exchange_value      = 3.76e-12
 anisotropy_value    = -139.26
=======================================================
iter = 1, M_mag_error_max = 0.1489814266
iter = 2, M_mag_error_max = 0.02241954938
iter = 3, M_mag_error_max = 0.003344750653
iter = 4, M_mag_error_max = 0.0007498694073
iter = 5, M_mag_error_max = 0.0001862717924
iter = 6, M_mag_error_max = 4.384224511e-05
iter = 7, M_mag_error_max = 1.113960298e-05
iter = 8, M_mag_error_max = 2.714305802e-06
iter = 9, M_mag_error_max = 7.037668044e-07
Advanced step 1 in 14.4891033 seconds
High-water FAB megabyte spread across MPI nodes: [348 ... 348]
Curent     FAB megabyte spread across MPI nodes: [348 ... 348]
iter = 1, M_mag_error_max = 0.1355607925
iter = 2, M_mag_error_max = 0.02079223546
iter = 3, M_mag_error_max = 0.002641455299
iter = 4, M_mag_error_max = 0.0005645492217
iter = 5, M_mag_error_max = 0.0001363801193
iter = 6, M_mag_error_max = 3.412621199e-05
iter = 7, M_mag_error_max = 9.080454565e-06
iter = 8, M_mag_error_max = 2.445929319e-06
iter = 9, M_mag_error_max = 6.630928298e-07
Advanced step 2 in 14.39318424 seconds
High-water FAB megabyte spread across MPI nodes: [348 ... 348]
Curent     FAB megabyte spread across MPI nodes: [348 ... 348]
iter = 1, M_mag_error_max = 0.1076802972
iter = 2, M_mag_error_max = 0.01700277684
iter = 3, M_mag_error_max = 0.002841017099
iter = 4, M_mag_error_max = 0.0006859039837
iter = 5, M_mag_error_max = 0.0001726186096
iter = 6, M_mag_error_max = 4.34297178e-05
iter = 7, M_mag_error_max = 1.103904149e-05
iter = 8, M_mag_error_max = 2.854099255e-06
iter = 9, M_mag_error_max = 7.355508949e-07
Advanced step 3 in 14.58411943 seconds
High-water FAB megabyte spread across MPI nodes: [348 ... 348]
Curent     FAB megabyte spread across MPI nodes: [348 ... 348]
```