### PR TITLE
Remove amrex/sundials time integrator lines from input

### DIFF
--- a/Exec/GNUmakefile
+++ b/Exec/GNUmakefile
@@ -9,6 +9,7 @@ COMP         = gnu
 DIM          = 3
 
 NEUMANN = FALSE
+USE_TIME_INTEGRATOR = FALSE
 USE_SUNDIALS = FALSE
 
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -15,7 +15,9 @@
 #include "EvolveM.H"
 #include "EvolveM_2nd.H"
 #include "Checkpoint.H"
+#ifdef USE_TIME_INTEGRATOR
 #include <AMReX_TimeIntegrator.H>
+#endif
 
 using namespace amrex;
 
@@ -469,8 +471,10 @@ void main_main ()
 
     }
 
+#ifdef USE_TIME_INTEGRATOR
     TimeIntegrator<Vector<MultiFab> > integrator(Mfield_old);
-    
+#endif 
+
     for (int step = start_step; step <= nsteps; ++step)
     {
 
@@ -706,7 +710,9 @@ void main_main ()
 
 
         }  else if (TimeIntegratorOption == 4) { // amrex and sundials integrators
-        amrex::Print() << "TimeIntegratorOption = SUNDIALS" << "\n";
+
+#ifdef USE_TIME_INTEGRATOR
+            amrex::Print() << "TimeIntegratorOption = SUNDIALS" << "\n";
 
 	    // Create a RHS source function we will integrate
             auto source_fun = [&](Vector<MultiFab>& rhs, const Vector<MultiFab>& old_state, const Real /*time*/){
@@ -761,6 +767,7 @@ void main_main ()
             
             // integrate forward one step from `time` by `dt` to fill S_new
             integrator.advance(Mfield_old, Mfield, time, dt);
+#endif
 
         }  else {
             amrex::Abort("Time integrator order not recognized");


### PR DESCRIPTION
This PR adds an option to run with our own time integrator schemes (`TimeIntegratorOption = 1/2/3`) without the need to keep lines with amrex/sundials integrator commands in the input file.